### PR TITLE
Addon file system fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ install:
   - pip install pytest mock
 
 # command to run tests
-script: py.test -v
+script: 
+  - cd service.notrobro.tests
+  - py.test -v
+  - cd ../../
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ install:
 
 # command to run tests
 script: 
-  - cd service.notrobro.tests
+  - cd service.notrobro/tests
   - py.test -v
   - cd ../../
 

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -3,9 +3,10 @@
 ## Prerequisites:
 ffmpeg need to be installed beforehand globally and should be able to run via the command line interface. 
 
-Make sure you have any requirement python libraries by running: 
+Make sure you have any required python libraries by running: 
 
 ```
+
 pip3 -r requirements.txt
 
 ```

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -3,6 +3,12 @@
 ## Prerequisites:
 ffmpeg need to be installed beforehand globally and should be able to run via the command line interface. 
 
+Make sure you have any requirement python libraries by running: 
+
+```
+pip3 -r requirements.txt
+
+```
 
 ## Detector arguments:
 Argument | Description

--- a/notrobro-detector/requirements.txt
+++ b/notrobro-detector/requirements.txt
@@ -1,0 +1,1 @@
+imagehash

--- a/service.notrobro/addon.xml
+++ b/service.notrobro/addon.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.notrobro" name="notrobro" version="0.0.1" provider-name="mohit">
     <requires>
-        <import addon="xbmc.python" version="2.25.0"/>
-
-
+        <import addon="xbmc.python" version="2.26.0"/>
     </requires>
     <extension point="xbmc.service" library="main.py"/>
     <extension point="xbmc.addon.metadata">
         <source>https://github.com/xbmc/notrobro</source>
         <summary lang="en_GB">Skip intros and outros</summary>
-        <description lang="en_GB"></description>
+        <description lang="en_GB">Reads EDL files to prompt for skipping intros and outros for TV show episodes</description>
         <platform>all</platform>
         <license>GPL-3.0</license>
         <website>www.kodi.tv</website>

--- a/service.notrobro/resources/lib/notrobroparser.py
+++ b/service.notrobro/resources/lib/notrobroparser.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import xbmcvfs
 
 
 class NotrobroParser():
@@ -12,9 +13,10 @@ class NotrobroParser():
         name, _ = os.path.splitext(file)
         file_name = name + ".edl"
         timings = []
-        if os.path.exists(file_name):
-            with open(file_name, "r") as f:
-                timings = f.readlines()
+        if xbmcvfs.exists(file_name):
+            f = xbmcvfs.File(file_name)
+            timings = f.read().split('\n')
+            f.close()
         else:
             self.logger.debug("Timings file not found.")
         return timings

--- a/service.notrobro/tests/conftest.py
+++ b/service.notrobro/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+import xbmcvfs as fxbmc
+
+module = type(sys)('xbmcvfs')
+module.exists = fxbmc.exists
+module.File = fxbmc.File
+sys.modules['xbmcvfs'] = module

--- a/service.notrobro/tests/conftest.py
+++ b/service.notrobro/tests/conftest.py
@@ -1,5 +1,5 @@
 import sys
-import xbmcvfs as fxbmc
+from . import xbmcvfs as fxbmc
 
 module = type(sys)('xbmcvfs')
 module.exists = fxbmc.exists

--- a/service.notrobro/tests/xbmcvfs/__init__.py
+++ b/service.notrobro/tests/xbmcvfs/__init__.py
@@ -1,0 +1,22 @@
+import os
+
+
+# this exists just to serve as placeholder for the real xbmcvfs available within Kodi at runtime for testing
+def exists(file):
+    return os.path.exists(file)
+
+
+class File:
+    filename = None
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def read(self):
+        result = None
+        with open(self.filename, "r") as f:
+            result = f.readlines()
+        return ''.join(result) # xbmcvfs returns all lines as a single string
+
+    def close(self):
+        return True


### PR DESCRIPTION
Changed the parser to use the xbmcvfs module instead of the Python os functions. This was causing issues when opening videos files on a network device in Kodi. The EDL files could not be found. 

__Note__: python requirements stuff is s dup from the other PR I made. Again, sorry I'll do better in the future with these with different branches. 