### PR TITLE
Merge pull request #27 from robweber/multithreading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,10 @@ install:
   - pip install pytest mock
 
 # command to run tests
-script: py.test -v
+script: 
+  - cd service.notrobro/tests
+  - py.test -v
+  - cd ../../
 
 jobs:
   include:

--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@ Your friendly intro and outro detection robot
 
 ## notrobro-detector
 This is the part you can run on your server/against your files to generate a file that defines where intros and outros are
+
+## Bacgkround info
+
+https://docs.google.com/document/d/1AXIyxK6p3m_IQBWOgBDXxaUFi_457pSblPUQti9uEpo/

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -3,9 +3,10 @@
 ## Prerequisites:
 ffmpeg need to be installed beforehand globally and should be able to run via the command line interface. 
 
-Make sure you have any requirement python libraries by running: 
+Make sure you have any required python libraries by running: 
 
 ```
+
 pip3 -r requirements.txt
 
 ```

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -7,7 +7,7 @@ Make sure you have any required python libraries by running:
 
 ```
 
-pip3 -r requirements.txt
+pip3 install -r requirements.txt
 
 ```
 

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -17,7 +17,7 @@ Argument | Description
   --path PATH, -p PATH | TV show directory path (mandatory argument)
   -h, --help | show this help message and exit
   --threshold THRESHOLD, -t THRESHOLD | Threshold for scene change detection(default=0.35)
-  --method METHOD, -m METHOD | Method used for timings generation (all_match (default) or longest_common)
+  --method METHOD, -m METHOD | Method used for timings generation (all (default), all_match or longest_common)
   --force, -f | Process all videos in the directory (default=False)
 
 Minimum Required Command:

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -14,10 +14,11 @@ pip3 -r requirements.txt
 ## Detector arguments:
 Argument | Description
 --- | --- 
-  --path PATH, -p PATH | TV show directory path (mandatory argument)
+  --path PATH, -p PATH | TV show directory path (mandatory argument), can be a directory containing multiple shows in subdirectories
   -h, --help | show this help message and exit
-  --threshold THRESHOLD, -t THRESHOLD | Threshold for scene change detection(default=0.35)
+  --threshold THRESHOLD, -t THRESHOLD | Threshold for scene change detection (default=0.35)
   --method METHOD, -m METHOD | Method used for timings generation (all (default), all_match or longest_common)
+  --workers MAX, -w MAX | The total number of directories that can be processed at one time, each in its own thread (default=4)
   --force, -f | Process all videos in the directory (default=False)
 
 Minimum Required Command:
@@ -42,4 +43,10 @@ Change Method:
 ```shell
 	python3 detector.py --path /your/path/ --method longest_common
  	python3 detector.py -p /your/path/ -m longest_common
+```
+
+Run more workers:
+```shell
+        python3 detector.py --path /your/path --workers 5
+        python3 detector.py -p /your/path -w 5
 ```

--- a/notrobro-detector/README.md
+++ b/notrobro-detector/README.md
@@ -3,6 +3,12 @@
 ## Prerequisites:
 ffmpeg need to be installed beforehand globally and should be able to run via the command line interface. 
 
+Make sure you have any requirement python libraries by running: 
+
+```
+pip3 -r requirements.txt
+
+```
 
 ## Detector arguments:
 Argument | Description

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -100,6 +100,7 @@ class LongestContinousMethod(DetectorMethod):
         return []
 
 class Detector:
+    jpg_folder = './jpgs'  # location location of jpg images from video
     threshold = 0.35  # default threshold, can be passed as arg
     method = None  # detector method class
     debug = False
@@ -171,7 +172,7 @@ class Detector:
         outro_end_time = -300
 
         name, _ = os.path.splitext(path)
-
+        name = os.path.join(self.jpg_folder, os.path.basename(name))
         if os.path.exists(name):
             shutil.rmtree(name)
         os.mkdir(name)
@@ -214,9 +215,11 @@ class Detector:
             for i in range(len(scene_transitions)):
                 scene_transitions[i] = str(float(scene_transitions[i]) + begin)
         name, _ = os.path.splitext(path)
+        name = os.path.join(self.jpg_folder, os.path.basename(name))
         hashlist, _ = self.get_hash_from_dir(name)
         if os.path.exists(name) and not self.debug:
             shutil.rmtree(name)
+
         return hashlist, scene_transitions
 
 
@@ -337,6 +340,9 @@ class Detector:
             print("Add atleast 1 more video of the TV show to the directory for processing.")
             exit()
 
+        if(not os.path.exists(self.jpg_folder)):
+            os.mkdir(self.jpg_folder)
+
         # get videos which don't have a skip timings file (currently edl) according to --force parameter
         videos_process = []
         if force is False:
@@ -366,6 +372,9 @@ class Detector:
             timings = self.gen_timings_processed(
                 videos_process)
             self.create_edl(timings)
+
+        if(not self.debug):
+            shutil.rmtree(self.jpg_folder)
 
         print("Timing files created.")
 

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -269,6 +269,10 @@ class Detector:
         if(not os.path.exists(self.jpg_folder)):
             os.mkdir(self.jpg_folder)
 
+        # mark a file within the folder with the base path of this detector (for debug)
+        with open(os.path.join(self.jpg_folder, 'path.txt'), 'w') as f:
+            f.write(path)
+
         # get videos which don't have a skip timings file (currently edl) according to --force parameter
         videos_process = []
         if force is False:

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -331,7 +331,9 @@ class Detector:
 
 
     def generate(self, path, force):
-        #print(threading.current_thread().ident)
+        # jpg folder should have unique path for this thread
+        self.jpg_folder = './%d' % threading.current_thread().ident
+
         files = os.listdir(path)
         all_files = [os.path.join(path, i) for i in files]
 
@@ -377,8 +379,8 @@ class Detector:
                 videos_process)
             self.create_edl(timings)
 
-        #if(not self.debug):
-            #shutil.rmtree(self.jpg_folder)
+        if(not self.debug):
+            shutil.rmtree(self.jpg_folder)
 
 
 class DetectorThreadManager():

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -416,6 +416,7 @@ class DetectorThreadManager():
                 thread.join()
 
         print('All directories processed')
+        subprocess.call("stty sane", shell=True)
 
     def start_thread(self, dir):
         print('Starting detector in: %s' % dir)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -162,20 +162,23 @@ class Detector:
             indices = self.method.get_common_intro(hash_prev, hash_cur)
 
             if(len(indices) > 0):
-                intro_start_prev = scene_prev[indices[0][0]]
-                intro_start_cur = scene_cur[indices[0][1]]
+                try:
+                    intro_start_prev = scene_prev[indices[0][0]]
+                    intro_start_cur = scene_cur[indices[0][1]]
 
-                intro_end_prev = scene_prev[indices[-1][0] + 1]
-                intro_end_cur = scene_cur[indices[-1][1] + 1]
+                    intro_end_prev = scene_prev[indices[-1][0] + 1]
+                    intro_end_cur = scene_cur[indices[-1][1] + 1]
 
-                if 'intro' not in result[video_prev]:
-                    time_string = str(intro_start_prev) + " " + \
-                        str(intro_end_prev) + " 4"  # cut in edl files
-                    result[video_prev]['intro'] = time_string
+                    if 'intro' not in result[video_prev]:
+                        time_string = str(intro_start_prev) + " " + \
+                            str(intro_end_prev) + " 4"  # cut in edl files
+                        result[video_prev]['intro'] = time_string
 
-                time_string = str(intro_start_cur) + " " + \
-                        str(intro_end_cur) + " 4"  # cut in edl files
-                result[videos_process[i]]['intro'] = time_string
+                    time_string = str(intro_start_cur) + " " + \
+                            str(intro_end_cur) + " 4"  # cut in edl files
+                    result[videos_process[i]]['intro'] = time_string
+                except IndexError:
+                    logging.error('Error finding scene index')
             else:
                 logging.info('No intro found for: %s' % os.path.basename(videos_process[i]))
                 logging.debug('Comparison file: %s' % os.path.basename(video_prev))

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -10,310 +10,325 @@ import shutil
 import copy
 
 
-def get_hash(path):
-    return imagehash.phash(Image.open(path))
+class Detector:
+    threshold = 0.35  # default threshold, can be passed as arg
+    method = "all_match"  # default method, can be passed as arg
+    debug = False
 
 
-def get_hash_from_dir(path):
-    images = os.listdir(path)
-    images.sort()
-    hashlist = []
-    for img in images:
-        hashlist.append(get_hash(os.path.join(path, img)))
-    return hashlist, images
+    def  __init__(self, threshold, method, debug=False):
+        self.threshold = threshold
+        self.method = method
+        self.debug = debug
 
 
-def get_timings(out, category):
-    to_find = "pts_time:"
-    length = len(to_find)
-    loc = -1
-    times = []
-    while True:
-        loc = out.find(to_find, loc + 1)
-        if loc == -1:
-            break
-        time = ""
+    def get_hash(self, path):
+        return imagehash.phash(Image.open(path))
+
+
+    def get_hash_from_dir(self, path):
+        images = os.listdir(path)
+        images.sort()
+        hashlist = []
+        for img in images:
+            hashlist.append(self.get_hash(os.path.join(path, img)))
+        return hashlist, images
+
+
+    def get_timings(self, out, category):
+        to_find = "pts_time:"
+        length = len(to_find)
+        loc = -1
+        times = []
+        while True:
+            loc = out.find(to_find, loc + 1)
+            if loc == -1:
+                break
+            time = ""
+            current = loc + length
+            while out[current] != " ":
+                time += out[current]
+                current += 1
+            times.append(time)
+        if category is "intro":
+            del times[-1]
+        return times
+
+
+    def get_duration(self, out):
+        to_find = "Duration: "
+        length = len(to_find)
+        loc = out.find(to_find, 0)
+        duration = ""
         current = loc + length
-        while out[current] != " ":
-            time += out[current]
+        while out[current] != ",":
+            duration += out[current]
             current += 1
-        times.append(time)
-    if category is "intro":
-        del times[-1]
-    return times
+        total = duration.split(":")
+        to_sec = float(total[0])*3600.0 + float(total[1])*60.0 + float(total[1])
+        return to_sec
 
 
-def get_duration(out):
-    to_find = "Duration: "
-    length = len(to_find)
-    loc = out.find(to_find, 0)
-    duration = ""
-    current = loc + length
-    while out[current] != ",":
-        duration += out[current]
-        current += 1
-    total = duration.split(":")
-    to_sec = float(total[0])*3600.0 + float(total[1])*60.0 + float(total[1])
-    return to_sec
+    def get_scene_transitions(self, path, category):
+        th = self.threshold
+        end_time = 360  # in seconds (can be put in arguments as well)
+        # in seconds from end of video (can be put in arguments as well)
+        outro_end_time = -300
 
+        name, _ = os.path.splitext(path)
 
-def get_scene_transitions(path, threshold, category):
-    th = threshold
-    end_time = 360  # in seconds (can be put in arguments as well)
-    # in seconds from end of video (can be put in arguments as well)
-    outro_end_time = -300
+        if os.path.exists(name):
+            shutil.rmtree(name)
+        os.mkdir(name)
 
-    name, _ = os.path.splitext(path)
+        input_file = path
 
-    if os.path.exists(name):
-        shutil.rmtree(name)
-    os.mkdir(name)
+        if category is "intro":
+            scenes = "ffmpeg -i " + '"' + input_file + '"' + " -ss 0 -to " + \
+                str(end_time) + ' -vf  "select=' + "'gt(scene," + str(th) + ")'," + \
+                'showinfo" -vsync vfr "' + name + '/' + '"%04d.jpg>scenes 2>&1'
+        elif category is "outro":
+            scenes = "ffmpeg -sseof " + str(outro_end_time) + " -i " + '"' + input_file + '"' + ' -vf  "select=' + \
+                "'gt(scene," + str(th) + ")'," + 'showinfo" -vsync vfr "' + \
+                   name + '/' + '"%04d.jpg>scenes 2>&1'
 
-    input_file = path
+        subprocess.call(scenes, shell=True)
 
-    if category is "intro":
-        scenes = "ffmpeg -i " + '"' + input_file + '"' + " -ss 0 -to " + \
-            str(end_time) + ' -vf  "select=' + "'gt(scene," + str(th) + ")'," + \
-            'showinfo" -vsync vfr "' + name + '/' + '"%04d.jpg>scenes 2>&1'
-    elif category is "outro":
-        scenes = "ffmpeg -sseof " + str(outro_end_time) + " -i " + '"' + input_file + '"' + ' -vf  "select=' + \
-            "'gt(scene," + str(th) + ")'," + 'showinfo" -vsync vfr "' + \
-                 name + '/' + '"%04d.jpg>scenes 2>&1'
-
-    subprocess.call(scenes, shell=True)
-
-    file = open("scenes", "r")
-    out = file.read()
-    file.close()
-    times = get_timings(out, category)
-    os.remove("./scenes")
-
-    return times
-
-
-def get_hash_video(path, threshold, category):
-    scene_transitions = get_scene_transitions(path, threshold, category)
-    if category == "outro":
-        duration = "ffmpeg -i " + '"' + path + '"' + ">duration 2>&1"
-        subprocess.call(duration, shell=True)
-        file = open("duration", "r")
+        file = open("scenes", "r")
         out = file.read()
         file.close()
-        total_time = get_duration(out)
-        os.remove("./duration")
-        outro_end_time = -300
-        begin = total_time + outro_end_time
-        for i in range(len(scene_transitions)):
-            scene_transitions[i] = str(float(scene_transitions[i]) + begin)
-    name, _ = os.path.splitext(path)
-    hashlist, _ = get_hash_from_dir(name)
-    if os.path.exists(name):
-        shutil.rmtree(name)
-    return hashlist, scene_transitions
+        times = self.get_timings(out, category)
 
-# Methods
+        os.remove("./scenes")
 
-# (1) All common matches
+        return times
 
 
-def common_elements(list1, list2):
-    common = []
-    for i, element in enumerate(list1):
-        try:
-            ind = list2.index(element)
-            common.append((i, ind))
-        except:
-            pass
-    return common
+    def get_hash_video(self, path, category):
+        scene_transitions = self.get_scene_transitions(path, category)
+        if category == "outro":
+            duration = "ffmpeg -i " + '"' + path + '"' + ">duration 2>&1"
+            subprocess.call(duration, shell=True)
+            file = open("duration", "r")
+            out = file.read()
+            file.close()
+            total_time = self.get_duration(out)
+            os.remove("./duration")
+            outro_end_time = -300
+            begin = total_time + outro_end_time
+            for i in range(len(scene_transitions)):
+                scene_transitions[i] = str(float(scene_transitions[i]) + begin)
+        name, _ = os.path.splitext(path)
+        hashlist, _ = self.get_hash_from_dir(name)
+        if os.path.exists(name) and not self.debug:
+            shutil.rmtree(name)
+        return hashlist, scene_transitions
 
-# small modification for outros
+    # Methods
 
-
-def common_elements_outro(list1, list2):
-    common = []
-    for i, element1 in enumerate(list1):
-        for j, element2 in enumerate(list2):
-            if (element1-element2) <= 5:
-                if len(common) != 0 and common[-1][1] < j:
-                    common.append((i, j))
-                    break
-                elif len(common) == 0:
-                    common.append((i, j))
-                    break
-    return common
-
-# (2) Longest continuos match
+    # (1) All common matches
 
 
-def longest_common_subarray(l1, l2):
-    subarray = []
-    indices = []
-    len1, len2 = len(l1), len(l2)
-    for i in range(len1):
-        for j in range(len2):
-            temp = 0
-            cur_array = []
-            cur_indices = []
-            # hamming distance
-            while ((i+temp < len1) and (j+temp < len2) and (l1[i+temp]-l2[j+temp]) <= 30):
-                cur_array.append(l2[j+temp])
-                cur_indices.append((i+temp, j+temp))
-                temp += 1
-            if (len(cur_array) > len(subarray)):
-                subarray = cur_array
-                indices = cur_indices
-    # return subarray, indices
-    return indices
+    def common_elements(self, list1, list2):
+        common = []
+        for i, element in enumerate(list1):
+            try:
+                ind = list2.index(element)
+                common.append((i, ind))
+            except:
+                pass
+        return common
+
+    # small modification for outros
 
 
-def gen_timings_processed(videos_process, threshold, method):
-    intro_times = []
-    outro_times = []
+    def common_elements_outro(self, list1, list2):
+        common = []
+        for i, element1 in enumerate(list1):
+            for j, element2 in enumerate(list2):
+                if (element1-element2) <= 5:
+                    if len(common) != 0 and common[-1][1] < j:
+                        common.append((i, j))
+                        break
+                    elif len(common) == 0:
+                        common.append((i, j))
+                        break
+        return common
 
-    # Processing for Intros
-    hash_prev, scene_prev = get_hash_video(
-        videos_process[0], threshold, "intro")
+    # (2) Longest continuos match
 
-    print(0, "Intro")
-    for i in range(1, len(videos_process)):
-        hash_cur, scene_cur = get_hash_video(
-            videos_process[i], threshold, "intro")
-        if method == "all_match":
-            indices = common_elements(hash_prev, hash_cur)
 
-            intro_start_prev = scene_prev[indices[0][0]]
-            intro_start_cur = scene_cur[indices[0][1]]
+    def longest_common_subarray(self, l1, l2):
+        subarray = []
+        indices = []
+        len1, len2 = len(l1), len(l2)
+        for i in range(len1):
+            for j in range(len2):
+                temp = 0
+                cur_array = []
+                cur_indices = []
+                # hamming distance
+                while ((i+temp < len1) and (j+temp < len2) and (l1[i+temp]-l2[j+temp]) <= 30):
+                    cur_array.append(l2[j+temp])
+                    cur_indices.append((i+temp, j+temp))
+                    temp += 1
+                if (len(cur_array) > len(subarray)):
+                    subarray = cur_array
+                    indices = cur_indices
+        # return subarray, indices
+        return indices
 
-            intro_end_prev = scene_prev[indices[-1][0] + 1]
-            intro_end_cur = scene_cur[indices[-1][1] + 1]
 
-            if len(intro_times) == 0:
-                time_string = str(intro_start_prev) + " " + \
-                    str(intro_end_prev) + " 4"  # cut in edl files
+    def gen_timings_processed(self, videos_process):
+        intro_times = []
+        outro_times = []
+
+        # Processing for Intros
+        print("Finding Intros")
+        print("\t%s" % videos_process[0])
+
+        hash_prev, scene_prev = self.get_hash_video(
+            videos_process[0], "intro")
+
+        for i in range(1, len(videos_process)):
+            print("\t%s" % videos_process[i])
+            hash_cur, scene_cur = self.get_hash_video(
+                videos_process[i], "intro")
+            if self.method == "all_match":
+                indices = self.common_elements(hash_prev, hash_cur)
+
+                intro_start_prev = scene_prev[indices[0][0]]
+                intro_start_cur = scene_cur[indices[0][1]]
+
+                intro_end_prev = scene_prev[indices[-1][0] + 1]
+                intro_end_cur = scene_cur[indices[-1][1] + 1]
+
+                if len(intro_times) == 0:
+                    time_string = str(intro_start_prev) + " " + \
+                        str(intro_end_prev) + " 4"  # cut in edl files
+                    intro_times.append(time_string)
+
+                time_string = str(intro_start_cur) + " " + \
+                    str(intro_end_cur) + " 4"  # cut in edl files
+                intro_times.append(time_string)
+            elif self.method == "longest_common":
+                indices = self.longest_common_subarray(hash_prev, hash_cur)
+
+                intro_start_prev = scene_prev[indices[0][0]]
+                intro_start_cur = scene_cur[indices[0][1]]
+
+                intro_end_prev = scene_prev[indices[-1][0] + 1]
+                intro_end_cur = scene_cur[indices[-1][1] + 1]
+
+                if len(intro_times) == 0:
+                    time_string = str(intro_start_prev) + " " + \
+                        str(intro_end_prev) + " 4"  # cut in edl files
+                    intro_times.append(time_string)
+
+                time_string = str(intro_start_cur) + " " + \
+                    str(intro_end_cur) + " 4"  # cut in edl files
                 intro_times.append(time_string)
 
-            time_string = str(intro_start_cur) + " " + \
-                str(intro_end_cur) + " 4"  # cut in edl files
-            intro_times.append(time_string)
-        elif method == "longest_common":
-            indices = longest_common_subarray(hash_prev, hash_cur)
+            hash_prev = hash_cur
+            scene_prev = scene_cur
 
-            intro_start_prev = scene_prev[indices[0][0]]
-            intro_start_cur = scene_cur[indices[0][1]]
+        # Processing for Outros
+        print('Finding Outros')
+        print('\t%s' % videos_process[0])
 
-            intro_end_prev = scene_prev[indices[-1][0] + 1]
-            intro_end_cur = scene_cur[indices[-1][1] + 1]
+        hash_prev, scene_prev = self.get_hash_video(
+            videos_process[0], "outro")
 
-            if len(intro_times) == 0:
-                time_string = str(intro_start_prev) + " " + \
-                    str(intro_end_prev) + " 4"  # cut in edl files
-                intro_times.append(time_string)
+        for i in range(1, len(videos_process)):
+            print('\t%s' % videos_process[i])
+            hash_cur, scene_cur = self.get_hash_video(
+                videos_process[i], "outro")
+            indices = self.common_elements_outro(hash_prev, hash_cur)
+            outro_start_prev = scene_prev[indices[0][0]]
+            outro_start_cur = scene_cur[indices[0][1]]
 
-            time_string = str(intro_start_cur) + " " + \
-                str(intro_end_cur) + " 4"  # cut in edl files
-            intro_times.append(time_string)
+            try:
+                outro_end_prev = scene_prev[indices[-1][0] + 1]
+            except:
+                outro_end_prev = scene_prev[indices[-1][0]]
 
-        hash_prev = hash_cur
-        scene_prev = scene_cur
+            try:
+                outro_end_cur = scene_cur[indices[-1][1] + 1]
+            except:
+                outro_end_cur = scene_cur[indices[-1][1]]
 
-        print(i, "Intro")
+            if len(outro_times) == 0:
+                time_string = str(outro_start_prev) + " " + \
+                    str(outro_end_prev) + " 5"  # cut in edl files
+                outro_times.append(time_string)
 
-    # Processing for Outros
-    hash_prev, scene_prev = get_hash_video(
-        videos_process[0], threshold, "outro")
-    print(0, "Outro")
-
-    for i in range(1, len(videos_process)):
-        hash_cur, scene_cur = get_hash_video(
-            videos_process[i], threshold, "outro")
-        indices = common_elements_outro(hash_prev, hash_cur)
-        outro_start_prev = scene_prev[indices[0][0]]
-        outro_start_cur = scene_cur[indices[0][1]]
-
-        try:
-            outro_end_prev = scene_prev[indices[-1][0] + 1]
-        except:
-            outro_end_prev = scene_prev[indices[-1][0]]
-
-        try:
-            outro_end_cur = scene_cur[indices[-1][1] + 1]
-        except:
-            outro_end_cur = scene_cur[indices[-1][1]]
-
-        if len(outro_times) == 0:
-            time_string = str(outro_start_prev) + " " + \
-                str(outro_end_prev) + " 5"  # cut in edl files
+            time_string = str(outro_start_cur) + " " + \
+                str(outro_end_cur) + " 5"  # cut in edl files
             outro_times.append(time_string)
 
-        time_string = str(outro_start_cur) + " " + \
-            str(outro_end_cur) + " 5"  # cut in edl files
-        outro_times.append(time_string)
+            hash_prev = hash_cur
+            scene_prev = scene_cur
 
-        hash_prev = hash_cur
-        scene_prev = scene_cur
-
-        print(i, "Outro")
-
-    return intro_times, outro_times
+        return intro_times, outro_times
 
 
-def create_edl(videos, intro_timings, outro_timings):
-    for i, file in enumerate(videos):
-        filename, _ = os.path.splitext(file)
-        suffix = '.edl'
-        edl_file = filename + suffix
-        with open(edl_file, 'w') as f:
-            if i <= len(intro_timings) - 1:
-                f.write(intro_timings[i] + "\n")
-            if i <= len(outro_timings) - 1:
-                f.write(outro_timings[i] + "\n")
-
-
-def generate(path, threshold, method, force):
-    files = os.listdir(path)
-    all_files = [os.path.join(path, i) for i in files]
-
-    # get the video files
-    videos = []
-    for ext in ('*.mp4', '*.mkv', '*.avi', '*.mov', '*.wmv'):  # video formats - extendable
-        videos.extend(glob.glob(os.path.join(path, ext)))
-
-    # if there is only 1 video in the directory
-    if len(videos) == 1:
-        print("Add atleast 1 more video of the TV show to the directory for processing.")
-        exit()
-
-    # get videos which don't have a skip timings file (currently edl) according to --force parameter
-    videos_process = []
-    if force is False:
-        for file in videos:
+    def create_edl(self, videos, intro_timings, outro_timings):
+        for i, file in enumerate(videos):
             filename, _ = os.path.splitext(file)
             suffix = '.edl'
-            if (filename + suffix) not in all_files:
-                videos_process.append(file)
-    else:
-        videos_process = copy.deepcopy(videos)
+            edl_file = filename + suffix
+            with open(edl_file, 'w') as f:
+                if i <= len(intro_timings) - 1:
+                    f.write(intro_timings[i] + "\n")
+                if i <= len(outro_timings) - 1:
+                    f.write(outro_timings[i] + "\n")
 
-    if len(videos_process) == 0:
-        print("No videos to process.")
-        exit()
-    elif len(videos_process) == 1:
-        vid = videos_process[0]
-        videos.sort()  # basic ordering for videos by sorting based on season and episode
-        try:
-            comp_vid = videos[videos.index(vid) - 1]
-        except:
-            comp_vid = videos[videos.index(vid) + 1]
-        intro_times, outro_times = gen_timings_processed(
-            [comp_vid, vid], threshold, method)
-        create_edl([vid], [intro_times[1]], [outro_times[1]])
-    else:
-        videos_process.sort()  # basic ordering for videos by sorting based on season and episode
-        intro_times, outro_times = gen_timings_processed(
-            videos_process, threshold, method)
-        create_edl(videos_process, intro_times, outro_times)
 
-    print("Timing files created.")
+    def generate(self, path, force):
+        files = os.listdir(path)
+        all_files = [os.path.join(path, i) for i in files]
+
+        # get the video files
+        videos = []
+        for ext in ('*.mp4', '*.mkv', '*.avi', '*.mov', '*.wmv'):  # video formats - extendable
+            videos.extend(glob.glob(os.path.join(path, ext)))
+
+        # if there is only 1 video in the directory
+        if len(videos) == 1:
+            print("Add atleast 1 more video of the TV show to the directory for processing.")
+            exit()
+
+        # get videos which don't have a skip timings file (currently edl) according to --force parameter
+        videos_process = []
+        if force is False:
+            for file in videos:
+                filename, _ = os.path.splitext(file)
+                suffix = '.edl'
+                if (filename + suffix) not in all_files:
+                    videos_process.append(file)
+        else:
+            videos_process = copy.deepcopy(videos)
+
+        if len(videos_process) == 0:
+            print("No videos to process.")
+            exit()
+        elif len(videos_process) == 1:
+            vid = videos_process[0]
+            videos.sort()  # basic ordering for videos by sorting based on season and episode
+            try:
+                comp_vid = videos[videos.index(vid) - 1]
+            except:
+                comp_vid = videos[videos.index(vid) + 1]
+            intro_times, outro_times = self.gen_timings_processed(
+                [comp_vid, vid])
+            self.create_edl([vid], [intro_times[1]], [outro_times[1]])
+        else:
+            videos_process.sort()  # basic ordering for videos by sorting based on season and episode
+            intro_times, outro_times = self.gen_timings_processed(
+                videos_process)
+            self.create_edl(videos_process, intro_times, outro_times)
+
+        print("Timing files created.")
 
 
 def signal_handler(sig, frame):
@@ -331,6 +346,8 @@ def main():
                           help='Method used for timings generation (all_match or longest_common)', default='all_match')
     argparse.add_argument('--force', '-f', action='store_true',
                           help='Process all videos in the directory')
+    argparse.add_argument('--debug', '-d', action='store_true',
+                          help='Run in debug mode, keeps temp files for analysis')
     args = argparse.parse_args()
     signal.signal(signal.SIGINT, signal_handler)
 
@@ -350,7 +367,10 @@ def main():
         print("Enter correct method: (1) all_match (2) longest_common")
         exit()
 
-    generate(args.path, args.threshold, args.method, args.force)
+    print('Threshold: %s' % args.threshold)
+    print('Method: %s' % args.method)
+    detector = Detector(args.threshold, args.method, args.debug)
+    detector.generate(args.path, args.force)
 
 
 if __name__ == '__main__':

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -111,9 +111,11 @@ class Detector:
     debug = False
 
 
-    def  __init__(self, threshold, method, debug=False):
+    def  __init__(self, threshold, method, level='info'):
         self.threshold = threshold
-        self.debug = debug
+
+        if(level.lower() == 'debug'):
+            self.debug = True
 
         if(method == 'all_match'):
             self.method = AllMatchMethod()
@@ -424,7 +426,7 @@ class DetectorThreadManager():
 
     def start_thread(self, dir):
         logging.info('Starting detector in: %s' % dir)
-        detector = Detector(self.args.threshold, self.args.method, self.args.debug)
+        detector = Detector(self.args.threshold, self.args.method, self.args.log)
         detector.generate(dir, self.args.force)
 
 
@@ -446,14 +448,16 @@ def main():
                           help='How many directories to process (threads) at one time (default=4)', default=4)
     argparse.add_argument('--force', '-f', action='store_true',
                           help='Process all videos in the directory')
-    argparse.add_argument('--debug', '-d', action='store_true',
-                          help='Run in debug mode, keeps temp files for analysis')
+    argparse.add_argument('--log', '-l', type=str, choices=['info', 'debug'],
+                          help='Run in debug mode, keeps temp files for analysis', default='info')
     args = argparse.parse_args()
     signal.signal(signal.SIGINT, signal_handler)
 
-    if(args.debug):
-        logging.setLevel(logging.DEBUG)
-        logging.debug('DEBUG logging enabled')
+    # set the log level
+    log_level = getattr(logging, args.log.upper())
+    logging.basicConfig(format="%(levelname)s %(asctime)s %(threadName)s: %(message)s", level=log_level,
+                        datefmt="%H:%M:%S")
+    logging.debug('DEBUG logging enabled')
 
     if args.path is None:
         logging.info("Enter a directory path.")
@@ -479,6 +483,4 @@ def main():
     detector.start(args.path)
 
 if __name__ == '__main__':
-    logging.basicConfig(format="%(levelname)s %(asctime)s %(threadName)s: %(message)s", level=logging.INFO,
-                        datefmt="%H:%M:%S")
     main()

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -234,8 +234,7 @@ class Detector:
         result = {}  # dict containing path: {intro,outro} information
 
         # Processing for Intros
-        logging.info("Finding Intros")
-        logging.info("%s" % videos_process[0])
+        logging.info("Detecting intro for: %s" % os.path.basename(videos_process[0]))
 
         video_prev = videos_process[0]
         result[video_prev] = {}
@@ -243,7 +242,7 @@ class Detector:
             videos_process[0], "intro")
 
         for i in range(1, len(videos_process)):
-            logging.info("%s" % videos_process[i])
+            logging.info("Detecting intro for: %s" % os.path.basename(videos_process[i]))
             result[videos_process[i]] = {}
 
             hash_cur, scene_cur = self.get_hash_video(
@@ -266,22 +265,22 @@ class Detector:
                         str(intro_end_cur) + " 4"  # cut in edl files
                 result[videos_process[i]]['intro'] = time_string
             else:
-                logging.info('No intro found %s : %s' % (video_prev, videos_process[i]))
+                logging.info('No intro found for: %s' % os.path.basename(videos_process[i]))
+                logging.debug('Comparison file: %s' % os.path.basename(video_prev))
 
             video_prev = videos_process[i]
             hash_prev = hash_cur
             scene_prev = scene_cur
 
         # Processing for Outros
-        logging.info('Finding Outros')
-        logging.info('%s' % videos_process[0])
+        logging.info('Detecting outro for: %s' % os.path.basename(videos_process[0]))
 
         video_prev = videos_process[0]
         hash_prev, scene_prev = self.get_hash_video(
             videos_process[0], "outro")
 
         for i in range(1, len(videos_process)):
-            logging.info('%s' % videos_process[i])
+            logging.info('Detecting outro for: %s' % os.path.basename(videos_process[i]))
             hash_cur, scene_cur = self.get_hash_video(
                 videos_process[i], "outro")
             indices = self.method.get_common_outro(hash_prev, hash_cur)
@@ -309,7 +308,8 @@ class Detector:
                     str(outro_end_cur) + " 5"  # cut in edl files
                 result[videos_process[i]]['outro'] = time_string
             else:
-                logging.info('No outro found %s : %s' % (video_prev, videos_process[i]))
+                logging.info('No outro found for: %s' % os.path.basename(videos_process[i]))
+                logging.debug('Comparison file: %s' % os.path.basename(video_prev))
 
             video_prev = videos_process[i]
             hash_prev = hash_cur

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -262,7 +262,6 @@ class Detector:
         # if there is only 1 video in the directory
         if len(videos) == 1:
             logging.info("Add at least 1 more video of the TV show to the directory for processing.")
-            exit()
 
         if(not os.path.exists(self.jpg_folder)):
             os.mkdir(self.jpg_folder)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -240,20 +240,23 @@ class Detector:
                 videos_process[i], "intro")
             indices = self.method.get_common_intro(hash_prev, hash_cur)
 
-            intro_start_prev = scene_prev[indices[0][0]]
-            intro_start_cur = scene_cur[indices[0][1]]
+            if(len(indices) > 0):
+                intro_start_prev = scene_prev[indices[0][0]]
+                intro_start_cur = scene_cur[indices[0][1]]
 
-            intro_end_prev = scene_prev[indices[-1][0] + 1]
-            intro_end_cur = scene_cur[indices[-1][1] + 1]
+                intro_end_prev = scene_prev[indices[-1][0] + 1]
+                intro_end_cur = scene_cur[indices[-1][1] + 1]
 
-            if 'intro' not in result[video_prev]:
-                time_string = str(intro_start_prev) + " " + \
-                    str(intro_end_prev) + " 4"  # cut in edl files
-                result[video_prev]['intro'] = time_string
+                if 'intro' not in result[video_prev]:
+                    time_string = str(intro_start_prev) + " " + \
+                        str(intro_end_prev) + " 4"  # cut in edl files
+                    result[video_prev]['intro'] = time_string
 
-            time_string = str(intro_start_cur) + " " + \
-                    str(intro_end_cur) + " 4"  # cut in edl files
-            result[videos_process[i]]['intro'] = time_string
+                time_string = str(intro_start_cur) + " " + \
+                        str(intro_end_cur) + " 4"  # cut in edl files
+                result[videos_process[i]]['intro'] = time_string
+            else:
+                print('\t No intro found %s : %s' % (video_prev, videos_process[i]))
 
             video_prev = videos_process[i]
             hash_prev = hash_cur
@@ -272,27 +275,31 @@ class Detector:
             hash_cur, scene_cur = self.get_hash_video(
                 videos_process[i], "outro")
             indices = self.method.get_common_outro(hash_prev, hash_cur)
-            outro_start_prev = scene_prev[indices[0][0]]
-            outro_start_cur = scene_cur[indices[0][1]]
 
-            try:
-                outro_end_prev = scene_prev[indices[-1][0] + 1]
-            except:
-                outro_end_prev = scene_prev[indices[-1][0]]
+            if(len(indices) > 0):
+                outro_start_prev = scene_prev[indices[0][0]]
+                outro_start_cur = scene_cur[indices[0][1]]
 
-            try:
-                outro_end_cur = scene_cur[indices[-1][1] + 1]
-            except:
-                outro_end_cur = scene_cur[indices[-1][1]]
+                try:
+                    outro_end_prev = scene_prev[indices[-1][0] + 1]
+                except:
+                    outro_end_prev = scene_prev[indices[-1][0]]
 
-            if 'outro' not in result[video_prev]:
-                time_string = str(outro_start_prev) + " " + \
-                    str(outro_end_prev) + " 5"  # cut in edl files
-                result[video_prev]['outro'] = time_string
+                try:
+                    outro_end_cur = scene_cur[indices[-1][1] + 1]
+                except:
+                    outro_end_cur = scene_cur[indices[-1][1]]
 
-            time_string = str(outro_start_cur) + " " + \
-                str(outro_end_cur) + " 5"  # cut in edl files
-            result[videos_process[i]]['outro'] = time_string
+                if 'outro' not in result[video_prev]:
+                    time_string = str(outro_start_prev) + " " + \
+                        str(outro_end_prev) + " 5"  # cut in edl files
+                    result[video_prev]['outro'] = time_string
+
+                time_string = str(outro_start_cur) + " " + \
+                    str(outro_end_cur) + " 5"  # cut in edl files
+                result[videos_process[i]]['outro'] = time_string
+            else:
+                print('\t No intro found %s : %s' % (video_prev, videos_process[i]))
 
             video_prev = videos_process[i]
             hash_prev = hash_cur

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -24,7 +24,7 @@ class DetectorMethod(ABC):
 class AllMethods(DetectorMethod):
     methods = []
 
-    def __init(self):
+    def __init__(self):
         self.methods.append(AllMatchMethod())
         self.methods.append(LongestContinousMethod())
 

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -442,7 +442,7 @@ def main():
                           help='TV show directory path')
     argparse.add_argument('--threshold', '-t', type=str,
                           help='Threshold for scene change detection (default=0.35)', default='0.35')
-    argparse.add_argument('--method', '-m', type=str,
+    argparse.add_argument('--method', '-m', type=str, choices=["all_match", "longest_common", "all"],
                           help='Method used for timings generation (all, all_match, or longest_common). "all" method will run every method until a match is found or no methods are left to try', default='all')
     argparse.add_argument('--workers', '-w', type=int,
                           help='How many directories to process (threads) at one time (default=4)', default=4)
@@ -470,10 +470,6 @@ def main():
             if not os.path.isdir(args.path):
                 logging.info("Path: " + args.path + " is not a directory.")
                 exit()
-
-    if args.method not in ["all_match", "longest_common", "all"]:
-        logging.info("Enter correct method: (1) all (2) all_match or (3) longest_common")
-        exit()
 
     logging.info('Threshold: %s' % args.threshold)
     logging.info('Method: %s' % args.method)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -358,7 +358,6 @@ class Detector:
 
         if len(videos_process) == 0:
             print("No videos to process.")
-            break
         elif len(videos_process) == 1:
             vid = videos_process[0]
             videos.sort()  # basic ordering for videos by sorting based on season and episode
@@ -383,15 +382,17 @@ class Detector:
 
 class DetectorThreadManager():
     args = None  # args as passed from the CLI
+    executor = None  # thread pool executor
 
     def __init__(self, args):
         self.args = args
+        self.executor = ThreadPoolExecutor(max_workers=1)
 
     def start(self, base_dir):
         # start the walk
         for root, dirs, files in os.walk(base_dir):
             for name in dirs:
-                self.start_thread(os.path.join(root,name))
+                self.executor.submit(self.start_thread(os.path.join(root,name)))
 
     def start_thread(self,dir):
         print('Starting detector in: %s' % dir)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -382,7 +382,7 @@ def main():
     argparse.add_argument('--threshold', '-t', type=str,
                           help='Threshold for scene change detection(default=0.35)', default='0.35')
     argparse.add_argument('--method', '-m', type=str,
-                          help='Method used for timings generation (all_match, longest_common or all). "all" method will run every method until a match is found or no methods are left to try', default='all')
+                          help='Method used for timings generation (all, all_match, or longest_common). "all" method will run every method until a match is found or no methods are left to try', default='all')
     argparse.add_argument('--force', '-f', action='store_true',
                           help='Process all videos in the directory')
     argparse.add_argument('--debug', '-d', action='store_true',
@@ -403,7 +403,7 @@ def main():
                 exit()
 
     if args.method not in ["all_match", "longest_common", "all"]:
-        print("Enter correct method: (1) all_match (2) longest_common or (3) all")
+        print("Enter correct method: (1) all (2) all_match or (3) longest_common")
         exit()
 
     print('Threshold: %s' % args.threshold)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -358,7 +358,7 @@ class Detector:
 
         if len(videos_process) == 0:
             print("No videos to process.")
-            exit()
+            break
         elif len(videos_process) == 1:
             vid = videos_process[0]
             videos.sort()  # basic ordering for videos by sorting based on season and episode

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -1,5 +1,5 @@
+from methods import AllMethods, AllMatchMethod, LongestContinousMethod
 from argparse import ArgumentParser
-from abc import ABC, abstractmethod
 from PIL import Image
 import signal
 import sys
@@ -14,98 +14,8 @@ import time
 import logging
 
 
-class DetectorMethod(ABC):
-
-    @abstractmethod
-    def get_common_intro(self, l1, l2):
-        pass
-
-    @abstractmethod
-    def get_common_outro(self, l1, l2):
-        pass
-
-
-class AllMethods(DetectorMethod):
-    methods = []
-
-    def __init__(self):
-        self.methods.append(AllMatchMethod())
-        self.methods.append(LongestContinousMethod())
-
-
-    def get_common_intro(self, l1, l2):
-        result = []
-        i = 0
-        while(i < len(self.methods) and len(result) == 0):
-            result = self.methods[i].get_common_intro(l1,l2)
-            i = i + 1
-
-        return result
-
-    def get_common_outro(self, l1, l2):
-        result = []
-        i = 0
-        while(i < len(self.methods) and len(result) == 0):
-            result = self.methods[i].get_common_outro(l1,l2)
-            i = i + 1
-
-        return result
-
-
-class AllMatchMethod(DetectorMethod):
-
-    def get_common_intro(self, l1, l2):
-        common = []
-        for i, element in enumerate(l1):
-            try:
-                ind = l2.index(element)
-                common.append((i, ind))
-            except:
-                pass
-        return common
-
-    def get_common_outro(self, l1, l2):
-        common = []
-        for i, element1 in enumerate(l1):
-            for j, element2 in enumerate(l2):
-                if (element1-element2) <= 5:
-                    if len(common) != 0 and common[-1][1] < j:
-                        common.append((i, j))
-                        break
-                    elif len(common) == 0:
-                        common.append((i, j))
-                        break
-        return common
-
-
-class LongestContinousMethod(DetectorMethod):
-
-    def get_common_intro(self, l1, l2):
-        subarray = []
-        indices = []
-        len1, len2 = len(l1), len(l2)
-        for i in range(len1):
-            for j in range(len2):
-                temp = 0
-                cur_array = []
-                cur_indices = []
-                # hamming distance
-                while ((i+temp < len1) and (j+temp < len2) and (l1[i+temp]-l2[j+temp]) <= 30):
-                    cur_array.append(l2[j+temp])
-                    cur_indices.append((i+temp, j+temp))
-                    temp += 1
-                if (len(cur_array) > len(subarray)):
-                    subarray = cur_array
-                    indices = cur_indices
-        # return subarray, indices
-        return indices
-
-    def get_common_outro(self, l1, l2):
-        # not implemented for this method yet
-        return []
-
 class Detector:
-    jpg_folder = './jpgs'  # location location of jpg images from video
+    jpg_folder = './jpgs'  # location of jpg images from video
     threshold = 0.35  # default threshold, can be passed as arg
     method = None  # detector method class
     debug = False

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -171,17 +171,16 @@ class Detector:
                     intro_end_prev = scene_prev[indices[-1][0] + 1]
                     intro_end_cur = scene_cur[indices[-1][1] + 1]
 
+                    if 'intro' not in result[video_prev]:
+                        time_string = str(intro_start_prev) + " " + \
+                            str(intro_end_prev) + " 4"  # cut in edl files
+                        result[video_prev]['intro'] = time_string
+
+                    time_string = str(intro_start_cur) + " " + \
+                            str(intro_end_cur) + " 4"  # cut in edl files
+                    result[videos_process[i]]['intro'] = time_string
                 except IndexError:
                     logging.error('Error finding scene index')
-
-                if 'intro' not in result[video_prev]:
-                    time_string = str(intro_start_prev) + " " + \
-                        str(intro_end_prev) + " 4"  # cut in edl files
-                    result[video_prev]['intro'] = time_string
-
-                time_string = str(intro_start_cur) + " " + \
-                        str(intro_end_cur) + " 4"  # cut in edl files
-                result[videos_process[i]]['intro'] = time_string
 
             else:
                 logging.info('No intro found for: %s' % os.path.basename(videos_process[i]))

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -439,7 +439,7 @@ def signal_handler(sig, frame):
 def main():
     argparse = ArgumentParser()
     argparse.add_argument('--path', '-p', type=str,
-                          help='TV show directory path')
+                          help='TV show directory path', required=True)
     argparse.add_argument('--threshold', '-t', type=str,
                           help='Threshold for scene change detection (default=0.35)', default='0.35')
     argparse.add_argument('--method', '-m', type=str, choices=["all_match", "longest_common", "all"],
@@ -459,17 +459,13 @@ def main():
                         datefmt="%H:%M:%S")
     logging.debug('DEBUG logging enabled')
 
-    if args.path is None:
-        logging.info("Enter a directory path.")
+    if not os.path.exists(args.path):
+        logging.info("TV show directory: " + args.path + " not found.")
         exit()
     else:
-        if not os.path.exists(args.path):
-            logging.info("TV show directory: " + args.path + " not found.")
+        if not os.path.isdir(args.path):
+            logging.info("Path: " + args.path + " is not a directory.")
             exit()
-        else:
-            if not os.path.isdir(args.path):
-                logging.info("Path: " + args.path + " is not a directory.")
-                exit()
 
     logging.info('Threshold: %s' % args.threshold)
     logging.info('Method: %s' % args.method)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -327,6 +327,8 @@ class Detector:
                     if 'outro' in timings[file]:
                         f.write(timings[file]['outro'] + "\n")
 
+        print('Timing files created.')
+
 
     def generate(self, path, force):
         files = os.listdir(path)
@@ -376,8 +378,6 @@ class Detector:
 
         if(not self.debug):
             shutil.rmtree(self.jpg_folder)
-
-        print("Timing files created.")
 
 
 class DetectorThreadManager():

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -279,7 +279,7 @@ class Detector:
 
         if len(videos_process) == 0:
             logging.info("No videos to process.")
-        elif len(videos_process) == 1:
+        elif len(videos_process) == 1 and len(videos) >= 2:
             vid = videos_process[0]
             videos.sort()  # basic ordering for videos by sorting based on season and episode
             try:

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -63,23 +63,25 @@ class Detector:
                 time += out[current]
                 current += 1
             times.append(time)
-        if category is "intro":
+        if category is "intro" and len(times) > 0:
             del times[-1]
         return times
 
 
     def get_duration(self, out):
+        result = 0
         to_find = "Duration: "
         length = len(to_find)
         loc = out.find(to_find, 0)
-        duration = ""
-        current = loc + length
-        while out[current] != ",":
-            duration += out[current]
-            current += 1
-        total = duration.split(":")
-        to_sec = float(total[0])*3600.0 + float(total[1])*60.0 + float(total[1])
-        return to_sec
+        if(loc != -1):
+            duration = ""
+            current = loc + length
+            while out[current] != ",":
+                duration += out[current]
+                current += 1
+            total = duration.split(":")
+            result = float(total[0])*3600.0 + float(total[1])*60.0 + float(total[1])
+        return result
 
 
     def get_scene_transitions(self, path, category):

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -63,7 +63,7 @@ class Detector:
                 time += out[current]
                 current += 1
             times.append(time)
-        if category is "intro" and len(times) > 0:
+        if category == "intro" and len(times) > 0:
             del times[-1]
         return times
 
@@ -99,11 +99,11 @@ class Detector:
         input_file = path
 
         scene_file = os.path.join(self.jpg_folder, 'scenes')
-        if category is "intro":
+        if category == "intro":
             scenes = "ffmpeg -i " + '"' + input_file + '"' + " -ss 0 -to " + \
                 str(end_time) + ' -vf  "select=' + "'gt(scene," + str(th) + ")'," + \
                 'showinfo" -vsync vfr "' + name + '/' + '"%04d.jpg>' + scene_file + ' 2>&1'
-        elif category is "outro":
+        elif category == "outro":
             scenes = "ffmpeg -sseof " + str(outro_end_time) + " -i " + '"' + input_file + '"' + ' -vf  "select=' + \
                 "'gt(scene," + str(th) + ")'," + 'showinfo" -vsync vfr "' + \
                    name + '/' + '"%04d.jpg>' + scene_file + ' 2>&1'

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -180,23 +180,24 @@ class Detector:
 
         input_file = path
 
+        scene_file = os.path.join(self.jpg_folder, 'scenes')
         if category is "intro":
             scenes = "ffmpeg -i " + '"' + input_file + '"' + " -ss 0 -to " + \
                 str(end_time) + ' -vf  "select=' + "'gt(scene," + str(th) + ")'," + \
-                'showinfo" -vsync vfr "' + name + '/' + '"%04d.jpg>scenes 2>&1'
+                'showinfo" -vsync vfr "' + name + '/' + '"%04d.jpg>' + scene_file + ' 2>&1'
         elif category is "outro":
             scenes = "ffmpeg -sseof " + str(outro_end_time) + " -i " + '"' + input_file + '"' + ' -vf  "select=' + \
                 "'gt(scene," + str(th) + ")'," + 'showinfo" -vsync vfr "' + \
-                   name + '/' + '"%04d.jpg>scenes 2>&1'
+                   name + '/' + '"%04d.jpg>' + scene_file + ' 2>&1'
 
         subprocess.call(scenes, shell=True)
 
-        file = open("scenes", "r")
+        file = open(scene_file, "r")
         out = file.read()
         file.close()
         times = self.get_timings(out, category)
 
-        os.remove("./scenes")
+        os.remove(scene_file)
 
         return times
 
@@ -204,13 +205,14 @@ class Detector:
     def get_hash_video(self, path, category):
         scene_transitions = self.get_scene_transitions(path, category)
         if category == "outro":
-            duration = "ffmpeg -i " + '"' + path + '"' + ">duration 2>&1"
+            duration_file = os.path.join(self.jpg_folder, "duration")
+            duration = "ffmpeg -i " + '"' + path + '"' + ">" + duration_file + " 2>&1"
             subprocess.call(duration, shell=True)
-            file = open("duration", "r")
+            file = open(duration_file, "r")
             out = file.read()
             file.close()
             total_time = self.get_duration(out)
-            os.remove("./duration")
+            os.remove(duration_file)
             outro_end_time = -300
             begin = total_time + outro_end_time
             for i in range(len(scene_transitions)):

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -256,7 +256,7 @@ class Detector:
                         str(intro_end_cur) + " 4"  # cut in edl files
                 result[videos_process[i]]['intro'] = time_string
             else:
-                print('\t No intro found %s : %s' % (video_prev, videos_process[i]))
+                print('\tNo intro found %s : %s' % (video_prev, videos_process[i]))
 
             video_prev = videos_process[i]
             hash_prev = hash_cur
@@ -299,7 +299,7 @@ class Detector:
                     str(outro_end_cur) + " 5"  # cut in edl files
                 result[videos_process[i]]['outro'] = time_string
             else:
-                print('\t No intro found %s : %s' % (video_prev, videos_process[i]))
+                print('\tNo outro found %s : %s' % (video_prev, videos_process[i]))
 
             video_prev = videos_process[i]
             hash_prev = hash_cur

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -465,8 +465,7 @@ def main():
 
     print('Threshold: %s' % args.threshold)
     print('Method: %s' % args.method)
-    #detector = Detector(args.threshold, args.method, args.debug)
-    #detector.generate(args.path, args.force)
+    print('Max Workers: %d' % args.workers)
 
     detector = DetectorThreadManager(args)
     detector.start(args.path)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -305,7 +305,6 @@ class Detector:
             hash_prev = hash_cur
             scene_prev = scene_cur
 
-        print(str(result))
         return result
 
 

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -408,6 +408,10 @@ class DetectorThreadManager():
 
             time.sleep(2)
 
+        # wait for any final threads to finish
+        while(len(threading.enumerate()) > 1):
+            time.sleep(2)
+
         print('All directories processed')
 
     def start_thread(self, dir):

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -21,6 +21,31 @@ class DetectorMethod(ABC):
     def get_common_outro(self, l1, l2):
         pass
 
+class AllMethods(DetectorMethod):
+    methods = []
+
+    def __init(self):
+        self.methods.append(AllMatchMethod())
+        self.methods.append(LongestContinousMethod())
+
+
+    def get_common_intro(self, l1, l2):
+        result = []
+        i = 0
+        while(i < len(self.methods) and len(result) == 0):
+            result = self.methods[i].get_common_intro(l1,l2)
+            i = i + 1
+
+        return result
+
+    def get_common_outro(self, l1, l2):
+        result = []
+        i = 0
+        while(i < len(self.methods) and len(result) == 0):
+            result = self.methods[i].get_common_outro(l1,l2)
+            i = i + 1
+
+        return result
 
 class AllMatchMethod(DetectorMethod):
 
@@ -71,11 +96,12 @@ class LongestContinousMethod(DetectorMethod):
         return indices
 
     def get_common_outro(self, l1, l2):
+        # not implemented for this method yet
         return []
 
 class Detector:
     threshold = 0.35  # default threshold, can be passed as arg
-    method = None  # default method class
+    method = None  # detector method class
     debug = False
 
 
@@ -87,6 +113,8 @@ class Detector:
             self.method = AllMatchMethod()
         elif(method == 'longest_common'):
             self.method = LongestContinousMethod()
+        elif(method == 'all'):
+            self.method = AllMethods()
 
 
     def get_hash(self, path):
@@ -348,7 +376,7 @@ def main():
     argparse.add_argument('--threshold', '-t', type=str,
                           help='Threshold for scene change detection(default=0.35)', default='0.35')
     argparse.add_argument('--method', '-m', type=str,
-                          help='Method used for timings generation (all_match or longest_common)', default='all_match')
+                          help='Method used for timings generation (all_match, longest_common or all). "all" method will run every method until a match is found or no methods are left to try', default='all')
     argparse.add_argument('--force', '-f', action='store_true',
                           help='Process all videos in the directory')
     argparse.add_argument('--debug', '-d', action='store_true',
@@ -368,8 +396,8 @@ def main():
                 print("Path: " + args.path + " is not a directory.")
                 exit()
 
-    if args.method != "all_match" and args.method != "longest_common":
-        print("Enter correct method: (1) all_match (2) longest_common")
+    if args.method not in ["all_match", "longest_common", "all"]:
+        print("Enter correct method: (1) all_match (2) longest_common or (3) all")
         exit()
 
     print('Threshold: %s' % args.threshold)

--- a/notrobro-detector/detector.py
+++ b/notrobro-detector/detector.py
@@ -171,16 +171,18 @@ class Detector:
                     intro_end_prev = scene_prev[indices[-1][0] + 1]
                     intro_end_cur = scene_cur[indices[-1][1] + 1]
 
-                    if 'intro' not in result[video_prev]:
-                        time_string = str(intro_start_prev) + " " + \
-                            str(intro_end_prev) + " 4"  # cut in edl files
-                        result[video_prev]['intro'] = time_string
-
-                    time_string = str(intro_start_cur) + " " + \
-                            str(intro_end_cur) + " 4"  # cut in edl files
-                    result[videos_process[i]]['intro'] = time_string
                 except IndexError:
                     logging.error('Error finding scene index')
+
+                if 'intro' not in result[video_prev]:
+                    time_string = str(intro_start_prev) + " " + \
+                        str(intro_end_prev) + " 4"  # cut in edl files
+                    result[video_prev]['intro'] = time_string
+
+                time_string = str(intro_start_cur) + " " + \
+                        str(intro_end_cur) + " 4"  # cut in edl files
+                result[videos_process[i]]['intro'] = time_string
+
             else:
                 logging.info('No intro found for: %s' % os.path.basename(videos_process[i]))
                 logging.debug('Comparison file: %s' % os.path.basename(video_prev))

--- a/notrobro-detector/methods.py
+++ b/notrobro-detector/methods.py
@@ -1,0 +1,97 @@
+from abc import ABC, abstractmethod
+
+
+# abstract class, inherited by each Detector Method
+class DetectorMethod(ABC):
+
+    @abstractmethod
+    def get_common_intro(self, l1, l2):
+        pass
+
+    @abstractmethod
+    def get_common_outro(self, l1, l2):
+        pass
+
+
+# tries each method until a result is found or no methods left
+class AllMethods(DetectorMethod):
+    methods = []
+
+    def __init__(self):
+        self.methods.append(AllMatchMethod())
+        self.methods.append(LongestContinousMethod())
+
+
+    def get_common_intro(self, l1, l2):
+        result = []
+        i = 0
+        while(i < len(self.methods) and len(result) == 0):
+            result = self.methods[i].get_common_intro(l1,l2)
+            i = i + 1
+
+        return result
+
+    def get_common_outro(self, l1, l2):
+        result = []
+        i = 0
+        while(i < len(self.methods) and len(result) == 0):
+            result = self.methods[i].get_common_outro(l1,l2)
+            i = i + 1
+
+        return result
+
+
+# all_match method
+class AllMatchMethod(DetectorMethod):
+
+    def get_common_intro(self, l1, l2):
+        common = []
+        for i, element in enumerate(l1):
+            try:
+                ind = l2.index(element)
+                common.append((i, ind))
+            except:
+                pass
+        return common
+
+    def get_common_outro(self, l1, l2):
+        common = []
+        for i, element1 in enumerate(l1):
+            for j, element2 in enumerate(l2):
+                if (element1-element2) <= 5:
+                    if len(common) != 0 and common[-1][1] < j:
+                        common.append((i, j))
+                        break
+                    elif len(common) == 0:
+                        common.append((i, j))
+                        break
+        return common
+
+
+# longest_common method
+class LongestContinousMethod(DetectorMethod):
+
+    def get_common_intro(self, l1, l2):
+        subarray = []
+        indices = []
+        len1, len2 = len(l1), len(l2)
+        for i in range(len1):
+            for j in range(len2):
+                temp = 0
+                cur_array = []
+                cur_indices = []
+                # hamming distance
+                while ((i+temp < len1) and (j+temp < len2) and (l1[i+temp]-l2[j+temp]) <= 30):
+                    cur_array.append(l2[j+temp])
+                    cur_indices.append((i+temp, j+temp))
+                    temp += 1
+                if (len(cur_array) > len(subarray)):
+                    subarray = cur_array
+                    indices = cur_indices
+        # return subarray, indices
+        return indices
+
+    def get_common_outro(self, l1, l2):
+        # not implemented for this method yet
+        return []
+

--- a/notrobro-detector/methods.py
+++ b/notrobro-detector/methods.py
@@ -22,23 +22,25 @@ class AllMethods(DetectorMethod):
         self.methods.append(LongestContinousMethod())
 
 
-    def get_common_intro(self, l1, l2):
+    def _method_loop(self, l1, l2, method):
         result = []
         i = 0
         while(i < len(self.methods) and len(result) == 0):
-            result = self.methods[i].get_common_intro(l1,l2)
+            if(method == 'intro'):
+                result = self.methods[i].get_common_intro(l1, l2)
+            else:
+                result = self.methods[i].get_common_outro(l1, l2)
+
             i = i + 1
 
         return result
+
+
+    def get_common_intro(self, l1, l2):
+        return self._method_loop(l1, l2, 'intro')
 
     def get_common_outro(self, l1, l2):
-        result = []
-        i = 0
-        while(i < len(self.methods) and len(result) == 0):
-            result = self.methods[i].get_common_outro(l1,l2)
-            i = i + 1
-
-        return result
+        return self._method_loop(l1, l2, 'outro')
 
 
 # all_match method

--- a/notrobro-detector/requirements.txt
+++ b/notrobro-detector/requirements.txt
@@ -1,0 +1,1 @@
+imagehash

--- a/service.notrobro/addon.xml
+++ b/service.notrobro/addon.xml
@@ -1,15 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="service.notrobro" name="notrobro" version="0.0.1" provider-name="mohit">
     <requires>
-        <import addon="xbmc.python" version="2.25.0"/>
-
-
+        <import addon="xbmc.python" version="2.26.0"/>
     </requires>
     <extension point="xbmc.service" library="main.py"/>
     <extension point="xbmc.addon.metadata">
         <source>https://github.com/xbmc/notrobro</source>
         <summary lang="en_GB">Skip intros and outros</summary>
-        <description lang="en_GB"></description>
+        <description lang="en_GB">Reads EDL files to prompt for skipping intros and outros for TV show episodes</description>
         <platform>all</platform>
         <license>GPL-3.0</license>
         <website>www.kodi.tv</website>

--- a/service.notrobro/resources/lib/notrobroparser.py
+++ b/service.notrobro/resources/lib/notrobroparser.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import os
+import xbmcvfs
 
 
 class NotrobroParser():
@@ -12,9 +13,10 @@ class NotrobroParser():
         name, _ = os.path.splitext(file)
         file_name = name + ".edl"
         timings = []
-        if os.path.exists(file_name):
-            with open(file_name, "r") as f:
-                timings = f.readlines()
+        if xbmcvfs.exists(file_name):
+            f = xbmcvfs.File(file_name)
+            timings = f.read().split('\n')
+            f.close()
         else:
             self.logger.debug("Timings file not found.")
         return timings

--- a/service.notrobro/resources/lib/notrobroparser.py
+++ b/service.notrobro/resources/lib/notrobroparser.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 
 import os
-import xbmcvfs
 
 
 class NotrobroParser():
@@ -13,10 +12,9 @@ class NotrobroParser():
         name, _ = os.path.splitext(file)
         file_name = name + ".edl"
         timings = []
-        if xbmcvfs.exists(file_name):
-            f = xbmcvfs.File(file_name)
-            timings = f.read().split('\n')
-            f.close()
+        if os.path.exists(file_name):
+            with open(file_name, "r") as f:
+                timings = f.readlines()
         else:
             self.logger.debug("Timings file not found.")
         return timings

--- a/service.notrobro/tests/conftest.py
+++ b/service.notrobro/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from . import xbmcvfs as fxbmc
+
+module = type(sys)('xbmcvfs')
+module.exists = fxbmc.exists
+module.File = fxbmc.File
+sys.modules['xbmcvfs'] = module

--- a/service.notrobro/tests/xbmcvfs/__init__.py
+++ b/service.notrobro/tests/xbmcvfs/__init__.py
@@ -1,0 +1,22 @@
+import os
+
+
+# this exists just to serve as placeholder for the real xbmcvfs available within Kodi at runtime for testing
+def exists(file):
+    return os.path.exists(file)
+
+
+class File:
+    filename = None
+
+    def __init__(self, filename):
+        self.filename = filename
+
+    def read(self):
+        result = None
+        with open(self.filename, "r") as f:
+            result = f.readlines()
+        return ''.join(result) # xbmcvfs returns all lines as a single string
+
+    def close(self):
+        return True


### PR DESCRIPTION
This has all the updates from my now canceled PR (#25), as well as some more. These all modify the structure of the original files quite extensively, but the overall core functionality (ie the actual scene detection and comparison algorithms) are the exact same. 

Some of these are in reference to Issues you have already created. None of them change any core functionality and have been tested on multiple seasons of a few different TV series. Overall these changes allow the detector to complete, although not detect in all cases. The result is a few cases where intros/outros for individual files are not found; but the script overall completes. You end up with 4-5 files out of a full series with no resulting EDL file. Sometimes this is due to errors reading a file with ffmpeg, sometimes it's the video comparison done (ie, file with no intro, or an abbreviated intro for an episode) compared to one that does, and other issues. It is a lot better though than the original method of just exiting the program after one error with no EDL files generated. 

Here is a summary of the changes:

1. Added a requirements.txt file, I ran into a python error of missed deps the first time running this the first time. 
2. The [gen_timings_processed](https://github.com/robweber/notrobro/blob/multithreading/notrobro-detector/detector.py#L147) function now returns a dict in the form ```{file: {intro: X, outro: X}}```. The old way was 2 arrays that assumed an intro/outro for each file and was processed by index. It became obvious pretty quickly that there are always going to be files where an intro/outro was either not found, or just didn't exist. Almost all shows have a special or something where it skips, or severely changes, the intro sequence. 
3. Created the [methods.py](https://github.com/robweber/notrobro/blob/multithreading/notrobro-detector/methods.py) that abstracts the detection methods into classes. This allowed the merging of some duplicate code, as well as better method encapsulation. It also allowed for the creation of the now default "all" method. This runs both ```all_match``` and ```longest_common``` to find a match. I noticed that each algorithm had it's own use cases and when running across multiple directories it was best to try them both to get the best result. 
4. Added the [DetectorThreadManager](https://github.com/robweber/notrobro/blob/multithreading/notrobro-detector/detector.py#L312) class. This allows for directory walking and parallel processing of multiple directories. By default 4 workers allowed for processing of 4 directories at a time. This can be changed with the ```-w``` flag. #11
5. Changed the directory path for the jpg and other ancillary file generation. This path is now based on the the [thread id](https://github.com/robweber/notrobro/blob/multithreading/notrobro-detector/detector.py#L258) of an individual Detector instance. This eliminates any problems between threads trying to utilize the same directories or files while running. #13 
6. Used the ```logging``` module instead of ```print()``` statements. This makes the logs created via the individual threads easier to follow and allows for changing of the log level via the ```--log``` flag. #17
7. Fixed the #15 error. This happened under 2 scenarios. The first was just if no common indices were found. The original file assumed there would be common scenes. The second is if scenes are detected but the ending indexes don't line up. I saw this happen on shows that compared a "normal" intro of the show to one that basically started with a cold open (think special episode). You'd get a normal flash of the title card to start the intro common scene but then nothing after that. The timing generation would get a start index but not an ending. 
8. Numerous other small bug fixes and error checks to make sure things are functioning normally. 